### PR TITLE
SpriteFactory switch library from Rmagick to ImageMagick to avoid

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    ketcherails (0.1.5)
+    ketcherails (0.1.7)
       active_model_serializers (< 0.10.0)
       bootstrap-kaminari-views (= 0.0.5)
       bootstrap-sass
@@ -15,7 +15,7 @@ PATH
       delayed_job_active_record
       grape (< 2.0)
       grape-active_model_serializers (~> 1.3.2)
-      haml-rails (= 0.9.0)
+      haml-rails (~> 1.0.0)
       httparty
       jquery-rails
       jquery-ui-rails (~> 5.0.5)
@@ -67,7 +67,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.4)
-    autoprefixer-rails (9.5.1.1)
+    autoprefixer-rails (9.8.6.3)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -78,9 +78,9 @@ GEM
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     builder (3.2.4)
     byebug (11.0.1)
     climate_control (0.2.0)
@@ -102,7 +102,7 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     execjs (2.7.0)
-    ffi (1.10.0)
+    ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     grape (1.2.3)
@@ -117,12 +117,13 @@ GEM
       grape
     grape-swagger (0.32.1)
       grape (>= 0.16.2)
-    haml (4.0.7)
+    haml (5.1.2)
+      temple (>= 0.8.0)
       tilt
-    haml-rails (0.9.0)
+    haml-rails (1.0.0)
       actionpack (>= 4.0.1)
       activesupport (>= 4.0.1)
-      haml (>= 4.0.6, < 5.0)
+      haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     html2haml (2.2.0)
@@ -130,7 +131,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    httparty (0.18.0)
+    httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (0.9.5)
@@ -209,9 +210,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -225,16 +223,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    ruby_parser (3.14.2)
+    ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sexp_processor (4.14.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sexp_processor (4.15.1)
     sprite-factory (1.7.1)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -242,6 +237,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.1)
+    temple (0.8.2)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -258,7 +254,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-generators (~> 3.3.4)
-  bootstrap-sass (~> 3.3.5)
+  bootstrap-sass
   byebug
   grape
   grape-swagger

--- a/app/jobs/make_ketcherails_sprites.rb
+++ b/app/jobs/make_ketcherails_sprites.rb
@@ -15,7 +15,8 @@ class MakeKetcherailsSprites < ActiveJob::Base
       output_image: "#{SPRITES_PATH}ketcherails.png",
       margin: 1,
       layout: :packed,
-      nocomments: true
+      nocomments: true,
+      library: :image_magick
     )
 
 

--- a/app/jobs/make_menu_sprites.rb
+++ b/app/jobs/make_menu_sprites.rb
@@ -9,7 +9,8 @@ class MakeMenuSprites < ActiveJob::Base
       output_image: asset_path + 'images/ketcherails/sprite.png',
       margin: 1,
       layout: :packed,
-      nocomments: true
+      nocomments: true,
+      library: :image_magick
     )
   end
 end

--- a/ketcherails.gemspec
+++ b/ketcherails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.2.11"
   s.add_dependency "jquery-rails"
   s.add_dependency "nokogiri", ">=1.8.2", "< 2.0"
-  s.add_dependency "haml-rails", "0.9.0"
+  s.add_dependency "haml-rails", "~>1.0.0"
   s.add_dependency "jquery-ui-rails", "~> 5.0.5"
   s.add_dependency 'kaminari'
   s.add_dependency 'bootstrap-kaminari-views', '0.0.5'
@@ -48,5 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "byebug"
   s.add_development_dependency "rspec"
   s.add_development_dependency 'bootstrap-generators', '~> 3.3.4'
-  s.add_development_dependency 'bootstrap-sass', '~> 3.3.5'
+  s.add_development_dependency 'bootstrap-sass'
 end

--- a/lib/ketcherails/version.rb
+++ b/lib/ketcherails/version.rb
@@ -1,3 +1,3 @@
 module Ketcherails
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
opacity deprecation issue with Rmagick >= 4

gems update
increase  version

resolve #50 